### PR TITLE
add http support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ status_code.200:1|c
 response_time:100|ms
 ```
 
+### Per route example
+
 However, it's **highly recommended** that you set `req.statsdKey` which
 will be used to namespace the stats. Be aware that stats will only be logged
 once a response has been sent; this means that `req.statsdKey` can be
@@ -71,6 +73,24 @@ A GET request to `/` on this server would produce the following stats:
 ```
 http.get.home.status_code.200:1|c
 http.get.home.response_time:100|ms
+```
+
+### Plain http example
+
+This module also works with any `http` server
+
+```js
+var http = require('http');
+var expressStatsd = require('express-statsd');
+
+var monitorRequest = expressStatsd();
+
+http.createServer(function (req, res) {
+    monitorRequest(req, res);
+
+    // do whatever you want, framework, library, router
+    res.end('hello world');
+}).listen(3000);
 ```
 
 ## Options

--- a/lib/express-statsd.js
+++ b/lib/express-statsd.js
@@ -44,6 +44,8 @@ module.exports = function expressStatsdInit (options) {
     res.once('error', cleanup);
     res.once('close', cleanup);
 
-    next();
+    if (next) {
+      next();
+    }
   };
 };


### PR DESCRIPTION
I noticed this module really isn't express specific at all.

So I made the `next()` call optional and added an example of it working with `require('http')`
