### PR TITLE
Add sane default behavior for missing statsdKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,17 @@ response_time:100|ms
 
 ### Per route example
 
-However, it's **highly recommended** that you set `req.statsdKey` which
+The default behavior reports statsd metrics based on the top-level URI.
+For example:
+```
+https://www.domain.com/ --> root_GET.status_code.200:1|c
+https://www.domain.com/ --> root_GET.response_time.100|ms
+
+https://www.domain.com/something --> something_GET.status_code.200:1|c
+https://www.domain.com/something --> something_GET.response_time.100|ms
+```
+
+However, if you want to override this behavior you can set `req.statsdKey` which
 will be used to namespace the stats. Be aware that stats will only be logged
 once a response has been sent; this means that `req.statsdKey` can be
 set even after the express-statsd middleware was added to the chain. Here's an 

--- a/lib/express-statsd.js
+++ b/lib/express-statsd.js
@@ -9,8 +9,6 @@ module.exports = function expressStatsdInit (options) {
     port: 8125
   }, options);
 
-  assert(options.requestKey, 'express-statsd expects a requestKey');
-
   var client = options.client || new Lynx(options.host, options.port, options);
 
   return function expressStatsd (req, res, next) {
@@ -18,8 +16,15 @@ module.exports = function expressStatsdInit (options) {
 
     // Function called on response finish that sends stats to statsd
     function sendStats() {
+      var splitUrl = req.url.split('/');
       var key = req[options.requestKey];
       key = key ? key + '.' : '';
+
+      // Report timing based on top-level URI as default behavior
+      if (!key && splitUrl.length > 0) {
+        var topLevelURI = req.url.split('/')[1] || 'root';
+        key = topLevelURI + '_' + req.method + '.';
+      }
 
       // Status Code
       var statusCode = res.statusCode || 'unknown_status';

--- a/test/express-statsd.js
+++ b/test/express-statsd.js
@@ -27,16 +27,31 @@ describe('An express server', function () {
       });
 
       it('should send status_code stat', function () {
-        expect(this.messages[0]).to.match(/status_code\.200:\d\|c/);
+        expect(this.messages[0]).to.match(/root_GET.status_code\.200:\d\|c/);
       });
 
       it('should send response_time stat', function () {
-        expect(this.messages[1]).to.match(/response_time:\d\|ms/);
+        expect(this.messages[1]).to.match(/root_GET.response_time:\d\|ms/);
       });
 
       it('should send stats with no key', function () {
-        expect(this.messages[0]).to.match(/^status_code\.200:\d\|c$/);
-        expect(this.messages[1]).to.match(/^response_time:\d|ms$/);
+        expect(this.messages[0]).to.match(/^root_GET.status_code\.200:\d\|c$/);
+        expect(this.messages[1]).to.match(/^root_GET.response_time:\d|ms$/);
+      });
+    });
+
+    describe('receiving a request to /ninja', function () {
+      utils.runServer(1337, [
+        expressStatsd(),
+        function (req, res) {
+          res.send(200);
+        }
+      ]);
+      utils.saveRequest('http://localhost:1337/ninja');
+      utils.getStatsdMessages();
+
+      it('should send ninja_get.response_time stat', function () {
+        expect(this.messages[1]).to.match(/ninja_GET.response_time:\d\|ms/);
       });
     });
 


### PR DESCRIPTION
cc @Raynos @kumikoda @mlmorg 

Updated based on Jake's feedback:
-Don't provide a middleware
-I opted to provide a sane default for when the user does not provide a statsdKey
